### PR TITLE
Update DependencyChecker to use CommandExecutor.which

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: ../fastlane_core
   specs:
-    fastlane_core (0.30.0)
+    fastlane_core (0.32.1)
       babosa
       colored
       commander (>= 4.3.5)
@@ -235,7 +235,7 @@ GEM
       xcpretty (>= 0.2.1)
       xcpretty-travis-formatter (>= 0.0.3)
     security (0.1.3)
-    sentry-raven (0.15.2)
+    sentry-raven (0.15.3)
       faraday (>= 0.7.6)
     sigh (1.2.1)
       fastlane_core (>= 0.26.4, < 1.0.0)

--- a/lib/chiizu/dependency_checker.rb
+++ b/lib/chiizu/dependency_checker.rb
@@ -3,15 +3,14 @@ module Chiizu
     def self.check_dependencies
       return if Helper.test?
 
-      self.check_adb
+      check_adb
     end
 
     def self.check_adb
-      unless `adb version`.include? "Android Debug Bridge"
-        Helper.log.fatal '#############################################################'
-        Helper.log.fatal '# TODO Helpful error message'
-        Helper.log.fatal '#############################################################'
-        raise 'TODO Helpful error message'
+      unless FastlaneCore::CommandExecutor.which('adb')
+        UI.error 'The `adb` command could not be found on your PATH'
+        UI.error "Please ensure that the Android tools are installed and the platform-tools directory is present and on your PATH"
+        Ui.user_error! 'adb command not found'
       end
     end
   end


### PR DESCRIPTION
This requires the latest code in master from `fastlane_core` that has not yet received a version bump, so I have not yet adjusted the `chiizu.gemspec` to a new version.
