### PR TITLE
When parsing "adb devices" output, reject lines from the daemon startup

### DIFF
--- a/lib/chiizu/runner.rb
+++ b/lib/chiizu/runner.rb
@@ -65,8 +65,8 @@ module Chiizu
 
     def select_device
       devices = @executor.execute(command: "adb devices -l", print_all: true, print_command: true).split("\n")
-      # the first output by adb devices is "List of devices attached" so remove that
-      devices = devices.drop(1)
+      # the first output by adb devices is "List of devices attached" so remove that and any adb startup output
+      devices.reject! { |d| d.include?("List of devices attached") ||  d.include?("* daemon")}
 
       UI.user_error! 'There are no connected devices or emulators' if devices.empty?
 


### PR DESCRIPTION
Example output (when adb is not started):

```
List of devices attached
* daemon not running. starting it now on port 5037 *
* daemon started successfully *
emulator-5554          device product:sdk_google_phone_x86 model:Android_SDK_built_for_x86 device:generic_x86
```
