### PR TITLE
Remove requirement to pass Activity to Screengrab.screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
   </a>
 </h3>
 <p align="center">
-  <a href="https://github.com/fastlane/deliver">deliver</a> &bull; 
-  <b>screengrab</b> &bull; 
-  <a href="https://github.com/fastlane/frameit">frameit</a> &bull; 
-  <a href="https://github.com/fastlane/pem">pem</a> &bull; 
-  <a href="https://github.com/fastlane/sigh">sigh</a> &bull; 
+  <a href="https://github.com/fastlane/deliver">deliver</a> &bull;
+  <b>screengrab</b> &bull;
+  <a href="https://github.com/fastlane/frameit">frameit</a> &bull;
+  <a href="https://github.com/fastlane/pem">pem</a> &bull;
+  <a href="https://github.com/fastlane/sigh">sigh</a> &bull;
   <a href="https://github.com/fastlane/produce">produce</a> &bull;
   <a href="https://github.com/fastlane/cert">cert</a> &bull;
   <a href="https://github.com/fastlane/spaceship">spaceship</a> &bull;
@@ -35,7 +35,7 @@ screengrab
 
 ### Automates screenshots of your Android app
 
-Screengrab is a commandline tool that automates taking localized screenshots of your Android app. 
+Screengrab is a commandline tool that automates taking localized screenshots of your Android app.
 
 <img src="assets/running-screengrab.gif" width="640">
 
@@ -50,7 +50,7 @@ Screengrab is a commandline tool that automates taking localized screenshots of 
 
 Once this tool is officially released, the installation will be as simple as running `gem install screengrab`, and referencing a published Android AAR. For the private alpha, please follow these testing instructions:
 
-##### Command line tool installation 
+##### Command line tool installation
 1. Clone the repo with `git clone git@github.com:fastlane/screengrab.git`
 1. `cd` into your screengrab repo directory and run `rake install`
     - You may need to `gem install bundler` if you don't already have bundler
@@ -89,18 +89,18 @@ Ensure that the following permissions exist in your **src/debug/AndroidManifest.
 ##### Configuring your <a href="#ui-tests">UI Tests</a> for Screenshots
 
 1.  Add `@ClassRule public static final LocaleTestRule localeTestRule = new LocaleTestRule();` to your tests class to handle automatic switching of locales
-2.  To capture screenshots, add the following to your tests `Screengrab.screenshot(activity, "name_of_screenshot_here");` on the appropriate screens
+2.  To capture screenshots, add the following to your tests `Screengrab.screenshot("name_of_screenshot_here");` on the appropriate screens
 
 # Generating Screenshots with Screengrab
 - Then, before running `screengrab` you'll need a debug and test apk
   - You can create your APKs with `./gradlew assembleDebug assembleAndroidTest`
 - Once complete run `screengrab` in your app project directory to generate screenshots
     - You will be prompted to provide any required parameters which are not in your **Screengrabfile** or provided as command line arguments
-- Your screenshots will be saved in a /screenshots directory in the directory where you ran `screengrab`     
+- Your screenshots will be saved in a /screenshots directory in the directory where you ran `screengrab`
 
 ## Advanced Screengrabfile Configuration
 
-Running `screengrab init` generated a Screengrabfile which can store all of your configuration options. Since most values will not change often for your project, it is recommended to store them there. 
+Running `screengrab init` generated a Screengrabfile which can store all of your configuration options. Since most values will not change often for your project, it is recommended to store them there.
 
 The `Screengrabfile` is written in Ruby, so you may find it helpful to use an editor that highlights Ruby syntax to modify this file.
 
@@ -143,11 +143,11 @@ public class JUnit4StyleTests {
 
     @Test
     public void testTakeScreenshot() {
-        Screengrab.screenshot(activityRule.getActivity(), "before_button_click");
+        Screengrab.screenshot("before_button_click");
 
         onView(withId(R.id.fab)).perform(click());
 
-        Screengrab.screenshot(activityRule.getActivity(), "after_button_click");
+        Screengrab.screenshot("after_button_click");
     }
 }
 
@@ -160,9 +160,9 @@ When using JUnit 3 you'll need to add a bit more code:
 
 - Use `LocaleUtil.changeDeviceLocaleTo(LocaleUtil.getTestLocale());` in `setUp()`
 - Use `LocaleUtil.changeDeviceLocaleTo(LocaleUtil.getEndingLocale());` in `tearDown()`
-- Use `Screengrab.screenshot(activity, "name_of_screenshot_here");` to capture screenshots at the appropriate points in your tests
+- Use `Screengrab.screenshot("name_of_screenshot_here");` to capture screenshots at the appropriate points in your tests
 
-If you're having trouble getting your device unlocked and the screen activated to run tests, try using `ScreenUtil.activateScreenForTesting(activity);` in your test setup. 
+If you're having trouble getting your device unlocked and the screen activated to run tests, try using `ScreenUtil.activateScreenForTesting(activity);` in your test setup.
 
 ## [`fastlane`](https://fastlane.tools) Toolchain
 

--- a/example/src/androidTest/java/io/fabric/localetester/JUnit3StyleTests.java
+++ b/example/src/androidTest/java/io/fabric/localetester/JUnit3StyleTests.java
@@ -12,37 +12,33 @@ import static android.support.test.espresso.matcher.ViewMatchers.withId;
 
 public class JUnit3StyleTests extends ActivityInstrumentationTestCase2<MainActivity> {
 
-    private MainActivity activity;
-
     public JUnit3StyleTests() {
         super(MainActivity.class);
     }
 
     public void setUp() {
         LocaleUtil.changeDeviceLocaleTo(LocaleUtil.getTestLocale());
-        activity = getActivity();
-        ScreenUtil.activateScreenForTesting(activity);
+        ScreenUtil.activateScreenForTesting(getActivity());
     }
 
     public void tearDown() {
-        activity = null;
         LocaleUtil.changeDeviceLocaleTo(LocaleUtil.getEndingLocale());
     }
 
     public void testTakeScreenshot() {
-        Screengrab.screenshot(activity, "screenshot1");
+        Screengrab.screenshot("beforeFabClick");
 
         onView(withId(R.id.fab)).perform(click());
 
-        Screengrab.screenshot(activity, "screenshot2");
+        Screengrab.screenshot("afterFabClick");
     }
 
     public void testTakeMoreScreenshots() {
-        Screengrab.screenshot(activity, "screenshot3");
+        Screengrab.screenshot("mainActivity");
 
-        onView(withId(R.id.fab)).perform(click());
+        onView(withId(R.id.nav_button)).perform(click());
 
-        Screengrab.screenshot(activity, "screenshot4");
+        Screengrab.screenshot("anotherActivity");
     }
 }
 

--- a/example/src/androidTest/java/io/fabric/localetester/JUnit4StyleTests.java
+++ b/example/src/androidTest/java/io/fabric/localetester/JUnit4StyleTests.java
@@ -2,7 +2,6 @@ package io.fabric.localetester;
 
 import android.support.test.rule.ActivityTestRule;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -27,34 +26,26 @@ public class JUnit4StyleTests {
     @Rule
     public ActivityTestRule<MainActivity> activityRule = new ActivityTestRule<>(MainActivity.class);
 
-    private MainActivity activity;
-
     @Before
     public void setUp() {
-        activity = activityRule.getActivity();
-        ScreenUtil.activateScreenForTesting(activity);
-    }
-
-    @After
-    public void tearDown() {
-        activity = null;
+        ScreenUtil.activateScreenForTesting(activityRule.getActivity());
     }
 
     @Test
     public void testTakeScreenshot() {
-        Screengrab.screenshot(activity, "screenshot1");
+        Screengrab.screenshot("beforeFabClick");
 
         onView(withId(R.id.fab)).perform(click());
 
-        Screengrab.screenshot(activity, "screenshot2");
+        Screengrab.screenshot("afterFabClick");
     }
 
     @Test
     public void testTakeMoreScreenshots() {
-        Screengrab.screenshot(activity, "screenshot3");
+        Screengrab.screenshot("mainActivity");
 
-        onView(withId(R.id.fab)).perform(click());
+        onView(withId(R.id.nav_button)).perform(click());
 
-        Screengrab.screenshot(activity, "screenshot4");
+        Screengrab.screenshot("anotherActivity");
     }
 }

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -1,22 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.fabric.localetester"
-          xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="io.fabric.localetester" >
 
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme" >
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar" >
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
+                <action android:name="android.intent.action.MAIN" />
 
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".AnotherActivity"
+            android:label="@string/title_activity_another" >
         </activity>
     </application>
 

--- a/example/src/main/java/io/fabric/localetester/AnotherActivity.java
+++ b/example/src/main/java/io/fabric/localetester/AnotherActivity.java
@@ -1,0 +1,13 @@
+package io.fabric.localetester;
+
+import android.os.Bundle;
+import android.support.v7.app.ActionBarActivity;
+
+public class AnotherActivity extends ActionBarActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_another);
+    }
+}

--- a/example/src/main/java/io/fabric/localetester/MainActivity.java
+++ b/example/src/main/java/io/fabric/localetester/MainActivity.java
@@ -1,5 +1,6 @@
 package io.fabric.localetester;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
@@ -9,6 +10,7 @@ import android.text.format.DateFormat;
 import android.view.View;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.widget.Button;
 import android.widget.TextView;
 
 import java.util.Date;
@@ -27,6 +29,14 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 Snackbar.make(view, R.string.hello, Snackbar.LENGTH_LONG).show();
+            }
+        });
+
+        Button navButton = (Button) findViewById(R.id.nav_button);
+        navButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                startActivity(new Intent(MainActivity.this, AnotherActivity.class));
             }
         });
 

--- a/example/src/main/res/layout/activity_another.xml
+++ b/example/src/main/res/layout/activity_another.xml
@@ -1,0 +1,15 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="io.fabric.localetester.AnotherActivity">
+
+    <TextView
+        android:text="@string/hello"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"/>
+
+</RelativeLayout>

--- a/example/src/main/res/layout/content_main.xml
+++ b/example/src/main/res/layout/content_main.xml
@@ -39,4 +39,11 @@
         android:gravity="center"
         android:textSize="32sp"/>
 
+    <Button
+        android:id="@+id/nav_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/date"
+        android:layout_centerHorizontal="true"
+        android:text="@string/navigate"/>
 </RelativeLayout>

--- a/example/src/main/res/menu/menu_another.xml
+++ b/example/src/main/res/menu/menu_another.xml
@@ -1,0 +1,7 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context="io.fabric.localetester.AnotherActivity">
+    <item android:id="@+id/action_settings" android:title="@string/action_settings"
+        android:orderInCategory="100" app:showAsAction="never" />
+</menu>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -2,4 +2,6 @@
     <string name="app_name">Locale Tester</string>
     <string name="action_settings">Settings</string>
     <string name="hello">Hello</string>
+    <string name="title_activity_another">AnotherActivity</string>
+    <string name="navigate">Navigate</string>
 </resources>

--- a/screengrab-lib/src/main/java/tools.fastlane.screengrab/Screengrab.java
+++ b/screengrab-lib/src/main/java/tools.fastlane.screengrab/Screengrab.java
@@ -10,6 +10,9 @@ import android.graphics.Canvas;
 import android.os.Build;
 import android.os.Environment;
 import android.os.Looper;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
+import android.support.test.runner.lifecycle.Stage;
 import android.util.Log;
 import android.view.View;
 
@@ -19,9 +22,13 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import tools.fastlane.screengrab.file.Chmod;
@@ -39,21 +46,66 @@ public class Screengrab {
     private static final int FULL_QUALITY = 100;
     private static final String SCREENGRAB_DIR_NAME = "screengrab";
 
-    public static File screenshot(Activity activity, String tag) {
-        if (!TAG_PATTERN.matcher(tag).matches()) {
+    public static File screenshot(String screenshotName) {
+        final Activity activity = getCurrentActivity();
+
+        if (activity == null) {
+            throw new IllegalStateException("Could not find a RESUMED Activity to take screenshot: " + screenshotName);
+        }
+
+        if (!TAG_PATTERN.matcher(screenshotName).matches()) {
             throw new IllegalArgumentException("Tag may only contain the letters a-z, A-Z, the numbers 0-9, " +
                     "underscores, and hyphens");
         }
         try {
             File screenshotDirectory = getFilesDirectory(activity.getApplicationContext(), Locale.getDefault());
-            String screenshotName = System.currentTimeMillis() + NAME_SEPARATOR + tag + EXTENSION;
-            File screenshotFile = new File(screenshotDirectory, screenshotName);
+            String screenshotFileName = System.currentTimeMillis() + NAME_SEPARATOR + screenshotName + EXTENSION;
+            File screenshotFile = new File(screenshotDirectory, screenshotFileName);
             takeScreenshot(activity, screenshotFile);
-            Log.d(TAG, "Captured screenshot \"" + tag + "\"");
+            Log.d(TAG, "Captured screenshot \"" + screenshotFileName + "\"");
             return screenshotFile;
         } catch (Exception e) {
             throw new RuntimeException("Unable to capture screenshot.", e);
         }
+    }
+
+    /**
+     * Blocks for up to 10 seconds waiting for an activity to be in the RESUMED state.
+     *
+     * @return The current activity in the RESUMED state, or <code>null</code> if no activity in
+     * this state could be found before the timeout.
+     */
+    private static Activity getCurrentActivity() {
+        BlockingQueue<Activity> resumedActivity = new ArrayBlockingQueue<>(1);
+
+        try {
+            new Thread(createResumedActivityFinder(resumedActivity)).start();
+            return resumedActivity.poll(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Log.e(TAG, "Interrupted while waiting for a RESUMED Activity.", e);
+        }
+
+        return null;
+    }
+
+    private static Runnable createResumedActivityFinder(final BlockingQueue<Activity> resumedActivity) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                while (resumedActivity.isEmpty()) {
+                    InstrumentationRegistry.getInstrumentation().runOnMainSync(new Runnable() {
+                        @Override
+                        public void run() {
+                            Iterator<Activity> activities = ActivityLifecycleMonitorRegistry.getInstance().getActivitiesInStage(Stage.RESUMED).iterator();
+
+                            if (activities.hasNext()) {
+                                resumedActivity.add(activities.next());
+                            }
+                        }
+                    });
+                }
+            }
+        };
     }
 
     private static void takeScreenshot(final Activity activity, File file) throws IOException {


### PR DESCRIPTION
Updates `Screengrab.screenshot` method to not take the `activity` parameter.  

This enables tests to navigate to different activities and take screenshots without the caller needing to find the current activity. 

Where you had 

``` java
Screengrab.screenshot(activity, "name_of_screenshot")
```

you now _just_ use 

``` java
Screengrab.screenshot("name_of_screenshot")
```
