### PR TITLE
Fix docs and template use of clear_previous_screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The `Screengrabfile` is written in Ruby, so you may find it helpful to use an ed
 locales ['en-US', 'fr-FR', 'it-IT']
 
 # clear all previously generated screenshots in your local output directory before creating new ones
-clear_previous_screenshots
+clear_previous_screenshots true
 ```
 
 For more information about all available options run

--- a/lib/assets/ScreengrabfileTemplate
+++ b/lib/assets/ScreengrabfileTemplate
@@ -9,7 +9,7 @@
 locales ['en-US', 'fr-FR', 'it-IT']
 
 # clear all previously generated screenshots in your local output directory before creating new ones
-clear_previous_screenshots
+clear_previous_screenshots true
 
 # For more information about all available options run
 #   screengrab --help


### PR DESCRIPTION
Some uses of `clear_previous_screenshots` were not including the boolean parameter, so it was defaulting to `false`, when our intent was to show how to make it be `true`
