### PR TITLE
Make Dir.glob() case-insensitive for Ruby 2.0.x and 2.1.x

### DIFF
--- a/lib/screengrab/runner.rb
+++ b/lib/screengrab/runner.rb
@@ -107,7 +107,7 @@ module Screengrab
     def clear_local_previous_screenshots
       if @config[:clear_previous_screenshots]
         UI.message "Clearing output directory of screenshots at #{@config[:output_directory]}"
-        files = Dir.glob(File.join('.', @config[:output_directory], '**', '*.png'))
+        files = Dir.glob(File.join('.', @config[:output_directory], '**', '*.png'), File::FNM_CASEFOLD)
         File.delete(*files)
       end
     end


### PR DESCRIPTION
We ran into this problem with `deliver` when searching for screenshots that happened to have differently cased extensions. fastlane/deliver#560
