### PR TITLE
Add some initial tests to screengrab

### DIFF
--- a/lib/screengrab/runner.rb
+++ b/lib/screengrab/runner.rb
@@ -9,10 +9,13 @@ module Screengrab
 
     attr_accessor :number_of_retries
 
-    def initialize
-      @executor = FastlaneCore::CommandExecutor
-      @config = Screengrab.config
-      @android_env = Screengrab.android_environment
+    def initialize(executor = FastlaneCore::CommandExecutor,
+                   config = Screengrab.config,
+                   android_env = Screengrab.android_environment)
+
+      @executor = executor
+      @config = config
+      @android_env = android_env
     end
 
     def run

--- a/screengrab.gemspec
+++ b/screengrab.gemspec
@@ -25,12 +25,13 @@ Gem::Specification.new do |spec|
 
   # Development only
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '~> 3.1.0'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'yard', '~> 0.8.7.4'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'fastlane'
+  spec.add_development_dependency 'activesupport'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec', '~> 3.1.0'
+  spec.add_development_dependency 'yard', '~> 0.8.7.4'
   spec.add_development_dependency 'rubocop', '~> 0.35.1'
   spec.add_development_dependency 'webmock', '~> 1.19.0'
 end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -1,0 +1,100 @@
+describe Screengrab::Runner do
+  let(:config) { {} }
+  let(:ui) { Screengrab::UI }
+  let(:mock_android_environment) { double(Screengrab.android_environment) }
+  let(:mock_executor) { class_double('FastlaneCore::CommandExecutor') }
+
+  before do
+    @runner = Screengrab::Runner.new(mock_executor, config, mock_android_environment)
+  end
+
+  def set_mock_adb_response(command, mock_response)
+    expect(mock_executor).to receive(:execute)
+      .with(hash_including(command: command))
+      .and_return(mock_response)
+  end
+
+  describe :validate_apk do
+    context 'no aapt' do
+      it 'prints an error unless aapt can be found' do
+        expect(mock_android_environment).to receive(:aapt_path).and_return nil
+        expect(mock_executor).not_to receive(:execute)
+        expect(ui).to receive(:important).with(/.*aapt.*could not be found/)
+
+        @runner.validate_apk('fake_apk_path')
+      end
+    end
+
+    context 'no permissions' do
+      it 'prints if permissions are missing' do
+        allow(mock_android_environment).to receive(:aapt_path).and_return 'fake_aapt_path'
+        set_mock_adb_response('fake_aapt_path dump permissions fake_apk_path', '')
+
+        expect(ui).to receive(:user_error!).with(/permission.* could not be found/).and_call_original
+
+        expect { @runner.validate_apk('fake_apk_path') }.to raise_fastlane_error
+      end
+    end
+  end
+
+  describe :select_device do
+    let (:adb_list_devices_command) { 'adb devices -l' }
+
+    context 'no devices' do
+      it 'does not find any active devices' do
+        adb_response = <<-ADB_OUTPUT.strip_heredoc
+        List of devices attached
+
+        ADB_OUTPUT
+        set_mock_adb_response(adb_list_devices_command, adb_response)
+
+        expect(ui).to receive(:user_error!).with(/no connected.* devices/).and_call_original
+
+        expect { @runner.select_device }.to raise_fastlane_error
+      end
+    end
+
+    context 'one device' do
+      it 'finds an active device' do
+        adb_response = <<-ADB_OUTPUT.strip_heredoc
+          List of devices attached
+          T065002LTT             device usb:437387264X product:ghost_retail model:XT1053 device:ghost
+
+
+        ADB_OUTPUT
+        set_mock_adb_response(adb_list_devices_command, adb_response)
+
+        expect(@runner.select_device).to eq('T065002LTT')
+      end
+    end
+
+    context 'multiple devices' do
+      it 'finds an active device' do
+        adb_response = <<-ADB_OUTPUT.strip_heredoc
+          List of devices attached
+          emulator-5554          device product:sdk_phone_x86_64 model:Android_SDK_built_for_x86_64 device:generic_x86_64
+          T065002LTT             device usb:437387264X product:ghost_retail model:XT1053 device:ghost
+
+        ADB_OUTPUT
+
+        set_mock_adb_response(adb_list_devices_command, adb_response)
+        expect(@runner.select_device).to eq('emulator-5554')
+      end
+    end
+
+    context 'one device booting' do
+      it 'finds an active device' do
+        adb_response = <<-ADB_OUTPUT.strip_heredoc
+          List of devices attached
+          emulator-5554 offline
+          T065002LTT  device
+
+        ADB_OUTPUT
+
+        set_mock_adb_response(adb_list_devices_command, adb_response)
+
+        expect(@runner.select_device).to eq('T065002LTT')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,10 @@
-require "coveralls"
+require 'coveralls'
 Coveralls.wear! unless ENV["FASTLANE_SKIP_UPDATE_CHECK"]
 
 require 'screengrab'
 require 'webmock'
+require 'pry'
+require 'active_support/core_ext/string/strip'
 
 # This module is only used to check the environment is currently a testing env
 module SpecHelper
@@ -24,4 +26,8 @@ ensure
     ENV.delete(k) unless old_vals.include?(k)
     ENV[k] = old_vals[k]
   end
+end
+
+def raise_fastlane_error
+  raise_error FastlaneCore::Interface::FastlaneError
 end


### PR DESCRIPTION
Adds tests to the `select_device` and `validate_apk` sections of the screengrab runner.
