### PR TITLE
Pull screenshots into Supply directory structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ coverage/
 
 example/.gradle
 example/build
-example/fastlane/screenshots
+example/fastlane/metadata
 
 screengrab-lib/build
 

--- a/lib/screengrab.rb
+++ b/lib/screengrab.rb
@@ -1,3 +1,6 @@
+require 'open3'
+require 'fileutils'
+
 require 'fastlane_core'
 
 require 'screengrab/version'
@@ -6,8 +9,6 @@ require 'screengrab/detect_values'
 require 'screengrab/dependency_checker'
 require 'screengrab/options'
 require 'screengrab/android_environment'
-
-require 'open3'
 
 module Screengrab
   # Use this to just setup the configuration attribute and set it later somewhere else

--- a/lib/screengrab/options.rb
+++ b/lib/screengrab/options.rb
@@ -3,9 +3,9 @@ require 'credentials_manager'
 
 module Screengrab
   class Options
-    def self.available_options
-      output_directory = (File.directory?("fastlane") ? "fastlane/screenshots" : "screenshots")
+    DEVICE_TYPES = ["phone", "sevenInch", "tenInch", "tv", "wear"].freeze
 
+    def self.available_options
       @@options ||= [
         FastlaneCore::ConfigItem.new(key: :android_home,
                                      short_option: "-n",
@@ -30,7 +30,7 @@ module Screengrab
                                      short_option: "-o",
                                      env_name: "SCREENGRAB_OUTPUT_DIRECTORY",
                                      description: "The directory where to store the screenshots",
-                                     default_value: output_directory),
+                                     default_value: File.join("fastlane", "metadata", "android")),
         FastlaneCore::ConfigItem.new(key: :skip_open_summary,
                                      env_name: 'SCREENGRAB_SKIP_OPEN_SUMMARY',
                                      description: "Don't open the summary after running `screengrab`",
@@ -75,7 +75,7 @@ module Screengrab
                                      short_option: "-k",
                                      default_value: Dir[File.join("app", "build", "outputs", "apk", "app-debug.apk")].last,
                                      verify_block: proc do |value|
-                                       raise "Could not find APK file at path '#{value}'".red unless File.exist?(value)
+                                       UI.user_error! "Could not find APK file at path '#{value}'" unless File.exist?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :tests_apk_path,
                                      env_name: 'SCREENGRAB_TESTS_APK_PATH',
@@ -84,13 +84,21 @@ module Screengrab
                                      short_option: "-b",
                                      default_value: Dir[File.join("app", "build", "outputs", "apk", "app-debug-androidTest-unaligned.apk")].last,
                                      verify_block: proc do |value|
-                                       raise "Could not find APK file at path '#{value}'".red unless File.exist?(value)
+                                       UI.user_error! "Could not find APK file at path '#{value}'" unless File.exist?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :specific_device,
                                      env_name: 'SCREENGRAB_SPECIFIC_DEVICE',
                                      optional: true,
                                      description: "Use the device or emulator with the given serial number or qualifier",
-                                     short_option: "-s")
+                                     short_option: "-s"),
+        FastlaneCore::ConfigItem.new(key: :device_type,
+                                     env_name: 'SCREENGRAB_DEVICE_TYPE',
+                                     description: "Type of device used for screenshots. Matches Google Play Types (phone, sevenInch, tenInch, tv, wear)",
+                                     short_option: "-d",
+                                     default_value: "phone",
+                                     verify_block: proc do |value|
+                                       UI.user_error! "device_type must be one of: #{DEVICE_TYPES}" unless DEVICE_TYPES.include?(value)
+                                     end)
       ]
     end
   end

--- a/screengrab-lib/src/main/java/tools.fastlane.screengrab/Screengrab.java
+++ b/screengrab-lib/src/main/java/tools.fastlane.screengrab/Screengrab.java
@@ -159,7 +159,7 @@ public class Screengrab {
     }
 
     private static String localeToDirName(Locale locale) {
-        return locale.getLanguage() + "-" + locale.getCountry();
+        return locale.getLanguage() + "-" + locale.getCountry() + "/images/screenshots";
     }
 
     private static void createPathTo(File dir) throws IOException {


### PR DESCRIPTION
The output of `screengrab` should go right into the fastlane/metadata directory where `supply` uploads from 
