### PR TITLE
Create screenshots dest_dir before copying to it

### DIFF
--- a/lib/screengrab/runner.rb
+++ b/lib/screengrab/runner.rb
@@ -269,6 +269,7 @@ module Screengrab
         # (Moved to: fastlane/metadata/android/en-US/images/phoneScreenshots)
         dest_dir = File.join(File.dirname(screenshots_dir), device_type_dir_name)
 
+        FileUtils.mkdir_p(dest_dir)
         FileUtils.cp_r(src_screenshots, dest_dir)
         FileUtils.rm_r(screenshots_dir)
         UI.success "Screenshots copied to #{dest_dir}"


### PR DESCRIPTION
If the device type dir (e.g. `phoneScreenshots`) doesn't exist before we attempt to relocate screenshots to it, we get

```
No such file or directory @ rb_sysopen - ./fastlane/metadata/android/en-US/images/phoneScreenshots/1455045426070_mainActivity.png
```
