### PR TITLE
Add Apache license attribution for Spoon dependencies

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Felix Krause
+Copyright (c) 2016 Twitter, Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,3 +19,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+Chmod.java and Screengrab.java based on work Copyright (c) Square, Inc,
+Used under permission of the Apache 2.0 License
+http://www.apache.org/licenses/LICENSE-2.0

--- a/screengrab-lib/src/main/java/tools.fastlane.screengrab/Screengrab.java
+++ b/screengrab-lib/src/main/java/tools.fastlane.screengrab/Screengrab.java
@@ -1,5 +1,23 @@
 // Derived from Spoon.java in square/spoon
-// Copyright 2013 Square, Inc.
+// https://github.com/square/spoon/blob/94584b46f6152e7033c2e3fe9997c8491d6fedd1/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
+/*
+   Copyright 2013 Square, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+// This file contains significant modifications from the original work
+// Modifications Copyright 2015, Twitter Inc
 
 package tools.fastlane.screengrab;
 

--- a/screengrab-lib/src/main/java/tools.fastlane.screengrab/file/Chmod.java
+++ b/screengrab-lib/src/main/java/tools.fastlane.screengrab/file/Chmod.java
@@ -1,4 +1,19 @@
 // Copied from Chmod.java in square/spoon
+// https://github.com/square/spoon/blob/3dc3401f6857916ed57f132c90563266d6011708/spoon-client/src/main/java/com/squareup/spoon/Chmod.java
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
 // Copyright 2013 Square, Inc.
 
 package tools.fastlane.screengrab.file;


### PR DESCRIPTION
Adds header licenses for the Spoon sources used.  Also copyrights to Twitter, Inc instead of @KrauseFx personally. :copyright: :white_check_mark: 
