### PR TITLE
Get Activity of a View if the Context is a ContextWrapper

### DIFF
--- a/screengrab-lib/src/main/java/tools.fastlane.screengrab/Screengrab.java
+++ b/screengrab-lib/src/main/java/tools.fastlane.screengrab/Screengrab.java
@@ -23,6 +23,7 @@ package tools.fastlane.screengrab;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.os.Build;
@@ -74,7 +75,11 @@ public class Screengrab {
 
             @Override
             public void perform(UiController uiController, View view) {
-                final Activity activity = (Activity) view.getContext();
+                final Activity activity = scanForActivity(view.getContext());
+
+                if (activity == null) {
+                    throw new IllegalStateException("Couldn't get the activity from the view context");
+                }
 
                 if (!TAG_PATTERN.matcher(screenshotName).matches()) {
                     throw new IllegalArgumentException("Tag may only contain the letters a-z, A-Z, the numbers 0-9, " +
@@ -89,6 +94,20 @@ public class Screengrab {
                 } catch (Exception e) {
                     throw new RuntimeException("Unable to capture screenshot.", e);
                 }
+            }
+
+            private Activity scanForActivity(Context context) {
+                if (context == null) {
+                    return null;
+
+                } else if (context instanceof Activity) {
+                    return (Activity) context;
+
+                } else if (context instanceof ContextWrapper) {
+                    return scanForActivity(((ContextWrapper) context).getBaseContext());
+                }
+
+                return null;
             }
         });
     }


### PR DESCRIPTION
In some cases calling View.getContext will return a ContextWrapper instead
of an Activity. This will cause a ClassCastException:

```
java.lang.ClassCastException: android.view.ContextThemeWrapper cannot be cast to android.app.Activity
at tools.fastlane.screengrab.Screengrab$1.perform(Screengrab.java:77)
```

The added code is based on [this Stackoverflow answer](http://stackoverflow.com/a/27434760/111777).
