### PR TITLE
Update screengrab to bring in fastlane_core with linux fixes

### DIFF
--- a/screengrab.gemspec
+++ b/screengrab.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane_core', '>= 0.36.1', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency 'fastlane_core', '>= 0.36.8', '< 1.0.0' # all shared code and dependencies
 
   # Development only
   spec.add_development_dependency 'bundler'

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 major=0
 minor=2
-patch=0
+patch=1


### PR DESCRIPTION
This fixes a crash while shelling out on linux systems.  Fix from https://github.com/fastlane/fastlane_core/pull/114
