### PR TITLE
Refactor version calc logic to be shared by example project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,3 +18,30 @@ allprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+Properties loadProperties(File propsFile) {
+    new Properties().with { props ->
+        propsFile.withInputStream { stream ->
+            props.load(stream)
+        }
+        props
+    }
+}
+
+/**
+ * @return an Array containing the [versionNameString, versionCodeInt]
+ */
+Object[] screengrabVersion(File propsFile) {
+    Properties versionProps = loadProperties(propsFile)
+
+    int versionMajor = (versionProps['major'] ?: 0) as int
+    int versionMinor = (versionProps['minor'] ?: 0) as int
+    int versionPatch = (versionProps['patch'] ?: 0) as int
+    
+    String versionNameString = [versionMajor, versionMinor, versionPatch].join('.')
+    int versionCodeInt = (1000000 * versionMajor) + (10000 * versionMinor) + (100 * versionPatch)
+
+    [versionNameString, versionCodeInt]
+}
+
+

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -29,6 +29,8 @@ android {
 }
 
 def supportLibVersion = '23.1.1'
+Object[] versionInfo = screengrabVersion(rootProject.file('version.properties'))
+String screengrabVersion = versionInfo[0] as String
 
 dependencies {
     compile "com.android.support:appcompat-v7:${supportLibVersion}"
@@ -41,7 +43,7 @@ dependencies {
     androidTestCompile 'com.android.support.test:rules:0.4.1'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.1'
     androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
-    androidTestCompile 'tools.fastlane:screengrab:0.1.2'
+    androidTestCompile "tools.fastlane:screengrab:${screengrabVersion}"
 
 // The following allows you to link directly against the source code of the screengrab lib project
 // for local development

--- a/screengrab-lib/build.gradle
+++ b/screengrab-lib/build.gradle
@@ -2,23 +2,9 @@ String lookupProperty(Project project, String gradlePropName, String envVarName)
     return project.hasProperty(gradlePropName) ? project.property(gradlePropName) : System.getenv()[envVarName]
 }
 
-Properties loadProperties(File propsFile) {
-    new Properties().with { props ->
-        propsFile.withInputStream { stream ->
-            props.load(stream)
-        }
-        props
-    }
-}
-
-Properties versionProps = loadProperties(rootProject.file('version.properties'))
-
-int versionMajor = (versionProps['major'] ?: 0) as int
-int versionMinor = (versionProps['minor'] ?: 0) as int
-int versionPatch = (versionProps['patch'] ?: 0) as int
-
-String versionNameString = [versionMajor, versionMinor, versionPatch].join('.')
-int versionCodeInt = (1000000 * versionMajor) + (10000 * versionMinor) + (100 * versionPatch)
+Object[] versionInfo = screengrabVersion(rootProject.file('version.properties'))
+String versionNameString = versionInfo[0] as String
+int versionCodeInt = versionInfo[1] as int
 
 buildscript {
     repositories {


### PR DESCRIPTION
This should remove the need to keep the version number of the screengrab lib up-to-date in the example project
